### PR TITLE
Chat memory, full department filter, duplicate-URL cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Services are organized across multiple dimensions:
 | `scripts/aggregate-crawl-results.js` | Scores discovery candidates (used by the catalog agent) |
 | `scripts/recover-links-from-crawl.js` | Scores recovery candidates for broken catalog URLs (used by the catalog agent) |
 | `scripts/sync-catalog.js` | Syncs the embedded catalog in `index.html` from `service-catalog-v8.json` |
+| `workers/navigator-chat-proxy.js` | Source for the Cloudflare Worker behind the chat assistant (deployed manually via the Cloudflare dashboard) |
 | `reports/` | Auto-generated catalog change reports (created by GitHub Actions) |
 | `archive/` | Retired code, including the Cloudflare crawl experiment and legacy manual checkers |
 | `README.md` | This file |

--- a/index.html
+++ b/index.html
@@ -364,6 +364,8 @@
     .filter-option input[type="checkbox"] { width: 16px; height: 16px; accent-color: var(--co-blue); }
     .filter-option label { font-size: 0.8125rem; color: var(--gray-700); cursor: pointer; flex: 1; }
     .filter-count { font-size: 0.6875rem; color: var(--gray-400); background: var(--gray-100); padding: 2px 6px; border-radius: 1rem; }
+    .filter-show-toggle { background: none; border: none; color: var(--co-blue); font-size: 0.8125rem; font-weight: 600; cursor: pointer; padding: 0.375rem 0; text-decoration: underline; }
+    .filter-show-toggle:hover { color: var(--co-blue-light); }
 
     .services-section { min-width: 0; }
 
@@ -1231,6 +1233,8 @@
         categoryFilter: 'Category',
         departmentFilter: 'Department',
         filter: 'Filter',
+        showAll: 'Show all',
+        showFewer: 'Show fewer',
 
         // Results
         showingServices: 'Showing',
@@ -1377,6 +1381,8 @@
         categoryFilter: 'Categoría',
         departmentFilter: 'Departamento',
         filter: 'Filtrar',
+        showAll: 'Mostrar todos',
+        showFewer: 'Mostrar menos',
 
         // Results
         showingServices: 'Mostrando',
@@ -2192,7 +2198,7 @@
       "en": "Find information about food assistance and nutrition programs available in Colorado, including SNAP, WIC, and school meal programs.",
       "es": "Encuentre información sobre programas de asistencia alimentaria y nutrición disponibles en Colorado, incluyendo SNAP, WIC y programas de comidas escolares."
     },
-    "url": "https://cdhs.colorado.gov/benefits-assistance/food-assistance",
+    "url": "https://cdhs.colorado.gov/food-assistance",
     "department": {
       "en": "Department of Human Services",
       "es": "Departamento de Servicios Humanos"
@@ -2742,7 +2748,7 @@
       "en": "Access employment resources, job training, and career services specifically designed for military veterans in Colorado.",
       "es": "Acceda a recursos de empleo, capacitación laboral y servicios de carrera diseñados específicamente para veteranos militares en Colorado."
     },
-    "url": "https://cdle.colorado.gov/veterans-services",
+    "url": "https://cdle.colorado.gov/jobs-training/veterans",
     "department": {
       "en": "Department of Labor and Employment",
       "es": "Departamento de Trabajo y Empleo"
@@ -3159,7 +3165,7 @@
       "en": "Search for specific types of healthcare facilities in your area, including hospitals, clinics, and long-term care facilities.",
       "es": "Busque tipos específicos de instalaciones de atención médica en su área, incluyendo hospitales, clínicas e instalaciones de cuidado a largo plazo."
     },
-    "url": "https://cdphe.colorado.gov/find-and-compare-facilities",
+    "url": "https://cdphe.colorado.gov/health-facilities/find-and-compare-facilities",
     "department": {
       "en": "Department of Public Health & Environment",
       "es": "Departamento de Salud Pública y Medio Ambiente"
@@ -4056,7 +4062,7 @@
       "en": "Pay fees associated with boiler inspections conducted by the Division of Oil and Public Safety.",
       "es": "Pague tarifas asociadas con inspecciones de calderas realizadas por la División de Petróleo y Seguridad Pública."
     },
-    "url": "https://ops.colorado.gov/payment",
+    "url": "https://ops.colorado.gov/Conveyance/PaymentsFees",
     "department": {
       "en": "Department of Labor and Employment",
       "es": "Departamento de Trabajo y Empleo"
@@ -4088,7 +4094,7 @@
       "en": "Pay fees related to petroleum storage tank permits and inspections in Colorado.",
       "es": "Pague tarifas relacionadas con permisos e inspecciones de tanques de almacenamiento de petróleo en Colorado."
     },
-    "url": "https://ops.colorado.gov/payment",
+    "url": "https://ops.colorado.gov/Conveyance/PaymentsFees",
     "department": {
       "en": "Department of Labor and Employment",
       "es": "Departamento de Trabajo y Empleo"
@@ -4184,7 +4190,7 @@
       "en": "Buy Colorado hunting licenses, including big game, small game, and combination licenses for residents and non-residents.",
       "es": "Compre licencias de caza de Colorado, incluyendo licencias de caza mayor, caza menor y combinadas para residentes y no residentes."
     },
-    "url": "https://www.cpwshop.com/",
+    "url": "https://www.cpwshop.com/home.page",
     "department": {
       "en": "Colorado Parks and Wildlife",
       "es": "Parques y Vida Silvestre de Colorado"
@@ -4216,7 +4222,7 @@
       "en": "Buy gift certificates that can be used for park passes, camping reservations, and other state park amenities.",
       "es": "Compre certificados de regalo que se pueden usar para pases de parques, reservaciones de campamentos y otras comodidades de parques estatales."
     },
-    "url": "https://www.cpwshop.com/",
+    "url": "https://www.cpwshop.com/home.page",
     "department": {
       "en": "Colorado Parks and Wildlife",
       "es": "Parques y Vida Silvestre de Colorado"
@@ -5240,7 +5246,7 @@
       "en": "Search and explore Colorado state parks based on available activities, amenities, accessibility features, and current conditions.",
       "es": "Busque y explore los parques estatales de Colorado basándose en actividades disponibles, comodidades, características de accesibilidad y condiciones actuales."
     },
-    "url": "https://cpw.state.co.us/placestogo/parks/Pages/default.aspx",
+    "url": "https://cpw.state.co.us/state-parks",
     "department": {
       "en": "Colorado Parks and Wildlife",
       "es": "Parques y Vida Silvestre de Colorado"
@@ -5272,7 +5278,7 @@
       "en": "Access real-time information about road conditions across Colorado, including weather impacts, construction, and travel alerts.",
       "es": "Acceda a información en tiempo real sobre condiciones de carreteras en todo Colorado, incluyendo impactos climáticos, construcción y alertas de viaje."
     },
-    "url": "https://www.cotrip.org/",
+    "url": "https://www.cotrip.org/home",
     "department": {
       "en": "Department of Transportation",
       "es": "Departamento de Transporte"
@@ -5816,7 +5822,7 @@
       "en": "Access comprehensive information about Colorado's K-12 education system, including academic standards, school choice options, and student support services.",
       "es": "Acceda a información completa sobre el sistema educativo K-12 de Colorado, incluyendo estándares académicos, opciones de elección escolar y servicios de apoyo estudiantil."
     },
-    "url": "https://www.cde.state.co.us/",
+    "url": "https://ed.cde.state.co.us/",
     "department": {
       "en": "Department of Education",
       "es": "Departamento de Educación"
@@ -6618,7 +6624,7 @@
       "en": "Submit an online application to become a certified instructor or training provider for meth lab cleanup in Colorado.",
       "es": "Envíe una solicitud en línea para convertirse en un instructor certificado o proveedor de capacitación para limpieza de laboratorios de metanfetaminas en Colorado."
     },
-    "url": "https://cdphe.colorado.gov/methlabcleanup",
+    "url": "https://cdphe.colorado.gov/hm/methlabcleanup",
     "department": {
       "en": "Department of Public Health & Environment",
       "es": "Departamento de Salud Pública y Medio Ambiente"
@@ -6777,7 +6783,7 @@
       "en": "Find information and resources on operating a licensed pet animal care facility in Colorado, including regulations and oversight.",
       "es": "Encuentre información y recursos sobre la operación de una instalación de cuidado de animales de compañía con licencia en Colorado, incluyendo regulaciones y supervisión."
     },
-    "url": "https://ag.colorado.gov/ics/pacfa",
+    "url": "https://ag.colorado.gov/animal-welfare/pet-animal-care-and-facilities-act",
     "department": {
       "en": "Department of Agriculture",
       "es": "Departamento de Agricultura"
@@ -6903,7 +6909,7 @@
       "en": "Submit a request for Colorado public records under the Colorado Open Records Act (CORA).",
       "es": "Envíe una solicitud de registros públicos de Colorado bajo la Ley de Registros Abiertos de Colorado (CORA)."
     },
-    "url": "https://oit.colorado.gov/cora-colorado-open-records-requests",
+    "url": "https://oit.colorado.gov/about-us/news/cora-colorado-open-records-requests",
     "department": {
       "en": "Office of Information Technology",
       "es": "Oficina de Tecnología de la Información"
@@ -6967,7 +6973,7 @@
       "en": "Access and manage your Colorado Parks and Wildlife digital hunting and fishing licenses via the CPW app or online portal.",
       "es": "Acceda y administre sus licencias digitales de caza y pesca de Parques y Vida Silvestre de Colorado a través de la aplicación CPW o el portal en línea."
     },
-    "url": "https://www.cpwshop.com/",
+    "url": "https://www.cpwshop.com/home.page",
     "department": {
       "en": "Colorado Parks and Wildlife",
       "es": "Parques y Vida Silvestre de Colorado"
@@ -7031,7 +7037,7 @@
       "en": "Apply for or renew a secure transportation service license, required for behavioral health secure transport providers.",
       "es": "Solicite o renueve una licencia de servicio de transporte seguro, requerida para proveedores de transporte seguro de salud conductual."
     },
-    "url": "https://cdphe.colorado.gov/emergency-care/emergency-medical-services",
+    "url": "https://cdphe.colorado.gov/ems",
     "department": {
       "en": "Department of Public Health & Environment",
       "es": "Departamento de Salud Pública y Medio Ambiente"
@@ -7217,7 +7223,7 @@
       "en": "Apply for Colorado Works, the state's Temporary Assistance for Needy Families (TANF) program that provides monthly cash assistance and employment support to families with children.",
       "es": "Solicite Colorado Works, el programa de Asistencia Temporal para Familias Necesitadas (TANF) del estado que proporciona asistencia en efectivo mensual y apoyo laboral a familias con hijos."
     },
-    "url": "https://cdhs.colorado.gov/benefits-assistance/cash-assistance/colorado-works-tanf",
+    "url": "https://cdhs.colorado.gov/colorado-works",
     "department": {
       "en": "Department of Human Services",
       "es": "Departamento de Servicios Humanos"
@@ -7885,7 +7891,7 @@
       "en": "Buy Colorado hunting, fishing, and outdoor recreation licenses through the official Colorado Parks and Wildlife online store.",
       "es": "Compre licencias de caza, pesca y recreación al aire libre de Colorado a través de la tienda oficial en línea de Parques y Vida Silvestre de Colorado."
     },
-    "url": "https://www.cpwshop.com/",
+    "url": "https://www.cpwshop.com/home.page",
     "department": {
       "en": "Colorado Parks and Wildlife",
       "es": "Parques y Vida Silvestre de Colorado"
@@ -7919,7 +7925,7 @@
       "en": "Check live road conditions, closures, travel alerts, and weather impacts across Colorado highways before you travel.",
       "es": "Consulte las condiciones de carreteras en vivo, cierres, alertas de viaje e impactos climáticos en las autopistas de Colorado antes de viajar."
     },
-    "url": "https://www.cotrip.org/",
+    "url": "https://www.cotrip.org/home",
     "department": {
       "en": "Department of Transportation",
       "es": "Departamento de Transporte"
@@ -9144,41 +9150,48 @@
       });
     }
 
+    const FILTER_VISIBLE_LIMIT = 12;
+
     function getFilterOptions(field) {
       const counts = {};
       serviceCatalog.forEach(s => {
         const value = s[field];
         if (value) counts[value] = (counts[value] || 0) + 1;
       });
-      return Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, 12);
+      return Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    }
+
+    function renderFilterGroup(titleKey, options, filterType, idPrefix) {
+      const optionsHtml = options.map(([value, count], i) => `
+        <div class="filter-option"${i >= FILTER_VISIBLE_LIMIT ? ' hidden' : ''}>
+          <input type="checkbox" id="${idPrefix}-${slugify(value)}" value="${escapeHtml(value)}" data-filter="${filterType}">
+          <label for="${idPrefix}-${slugify(value)}">${escapeHtml(value)}</label>
+          <span class="filter-count">${count}</span>
+        </div>
+      `).join('');
+
+      const toggleHtml = options.length > FILTER_VISIBLE_LIMIT ? `
+        <button type="button" class="filter-show-toggle" data-expanded="false" aria-expanded="false">
+          ${t('showAll')} (${options.length})
+        </button>
+      ` : '';
+
+      return `
+        <div class="filter-group">
+          <h3>${t(titleKey)}</h3>
+          ${optionsHtml}
+          ${toggleHtml}
+        </div>
+      `;
     }
 
     function renderFilters() {
       const categories = getFilterOptions('category');
       const departments = getFilterOptions('department');
 
-      filterGroups.innerHTML = `
-        <div class="filter-group">
-          <h3>${t('categoryFilter')}</h3>
-          ${categories.map(([cat, count]) => `
-            <div class="filter-option">
-              <input type="checkbox" id="cat-${slugify(cat)}" value="${cat}" data-filter="category">
-              <label for="cat-${slugify(cat)}">${cat}</label>
-              <span class="filter-count">${count}</span>
-            </div>
-          `).join('')}
-        </div>
-        <div class="filter-group">
-          <h3>${t('departmentFilter')}</h3>
-          ${departments.map(([dept, count]) => `
-            <div class="filter-option">
-              <input type="checkbox" id="dept-${slugify(dept)}" value="${dept}" data-filter="department">
-              <label for="dept-${slugify(dept)}">${dept}</label>
-              <span class="filter-count">${count}</span>
-            </div>
-          `).join('')}
-        </div>
-      `;
+      filterGroups.innerHTML =
+        renderFilterGroup('categoryFilter', categories, 'category', 'cat') +
+        renderFilterGroup('departmentFilter', departments, 'department', 'dept');
     }
 
     // Structured pills currently rendered, keyed by pill id, so the click
@@ -9464,11 +9477,27 @@
           const filterType = e.target.dataset.filter;
           const value = e.target.value;
           const set = filterType === 'category' ? state.selectedCategories : state.selectedDepartments;
-          
+
           if (e.target.checked) set.add(value);
           else set.delete(value);
           renderServices();
         }
+      });
+
+      // Expand/collapse filter groups that have more options than the
+      // default visible limit.
+      filterGroups.addEventListener('click', e => {
+        const toggle = e.target.closest('.filter-show-toggle');
+        if (!toggle) return;
+        const expanded = toggle.dataset.expanded === 'true';
+        const group = toggle.closest('.filter-group');
+        group.querySelectorAll('.filter-option').forEach((opt, i) => {
+          if (i >= FILTER_VISIBLE_LIMIT) opt.hidden = expanded;
+        });
+        toggle.dataset.expanded = String(!expanded);
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        const total = group.querySelectorAll('.filter-option').length;
+        toggle.textContent = expanded ? `${t('showAll')} (${total})` : t('showFewer');
       });
 
       document.getElementById('clearFilters').addEventListener('click', clearAll);
@@ -10134,17 +10163,12 @@
 
       let isLoading = false;
 
-      // Build a condensed catalog for the API (only essential fields)
-      function buildCatalogContext() {
-        return serviceCatalog.map(s => ({
-          name: s.name,
-          description: s.description,
-          url: s.url,
-          department: s.department,
-          category: s.category,
-          taskType: s.taskType
-        }));
-      }
+      // Conversation history sent with each message so the assistant
+      // remembers earlier turns. Raw text only (never rendered HTML).
+      // The worker fetches the service catalog itself, so the client no
+      // longer ships it with every message.
+      let chatHistory = [];
+      const MAX_HISTORY_TURNS = 10;
 
       // Open/close chat window
       function openChat() {
@@ -10242,7 +10266,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
               message: userMessage,
-              catalog: JSON.stringify(buildCatalogContext()),
+              history: chatHistory.slice(-MAX_HISTORY_TURNS),
               lang: currentLang
             })
           });
@@ -10254,6 +10278,9 @@
             addMessage(t('chatError'), 'error');
           } else {
             addMessage(data.reply, 'assistant');
+            chatHistory.push({ role: 'user', text: userMessage });
+            chatHistory.push({ role: 'assistant', text: data.reply });
+            chatHistory = chatHistory.slice(-MAX_HISTORY_TURNS);
           }
         } catch (error) {
           hideTyping();

--- a/service-catalog-v8.json
+++ b/service-catalog-v8.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.1.2",
+  "version": "8.1.3",
   "lastUpdated": "2026-06-10",
   "serviceCount": 230,
   "languages": [
@@ -732,7 +732,7 @@
         "en": "Find information about food assistance and nutrition programs available in Colorado, including SNAP, WIC, and school meal programs.",
         "es": "Encuentre información sobre programas de asistencia alimentaria y nutrición disponibles en Colorado, incluyendo SNAP, WIC y programas de comidas escolares."
       },
-      "url": "https://cdhs.colorado.gov/benefits-assistance/food-assistance",
+      "url": "https://cdhs.colorado.gov/food-assistance",
       "department": {
         "en": "Department of Human Services",
         "es": "Departamento de Servicios Humanos"
@@ -1282,7 +1282,7 @@
         "en": "Access employment resources, job training, and career services specifically designed for military veterans in Colorado.",
         "es": "Acceda a recursos de empleo, capacitación laboral y servicios de carrera diseñados específicamente para veteranos militares en Colorado."
       },
-      "url": "https://cdle.colorado.gov/veterans-services",
+      "url": "https://cdle.colorado.gov/jobs-training/veterans",
       "department": {
         "en": "Department of Labor and Employment",
         "es": "Departamento de Trabajo y Empleo"
@@ -1699,7 +1699,7 @@
         "en": "Search for specific types of healthcare facilities in your area, including hospitals, clinics, and long-term care facilities.",
         "es": "Busque tipos específicos de instalaciones de atención médica en su área, incluyendo hospitales, clínicas e instalaciones de cuidado a largo plazo."
       },
-      "url": "https://cdphe.colorado.gov/find-and-compare-facilities",
+      "url": "https://cdphe.colorado.gov/health-facilities/find-and-compare-facilities",
       "department": {
         "en": "Department of Public Health & Environment",
         "es": "Departamento de Salud Pública y Medio Ambiente"
@@ -2596,7 +2596,7 @@
         "en": "Pay fees associated with boiler inspections conducted by the Division of Oil and Public Safety.",
         "es": "Pague tarifas asociadas con inspecciones de calderas realizadas por la División de Petróleo y Seguridad Pública."
       },
-      "url": "https://ops.colorado.gov/payment",
+      "url": "https://ops.colorado.gov/Conveyance/PaymentsFees",
       "department": {
         "en": "Department of Labor and Employment",
         "es": "Departamento de Trabajo y Empleo"
@@ -2628,7 +2628,7 @@
         "en": "Pay fees related to petroleum storage tank permits and inspections in Colorado.",
         "es": "Pague tarifas relacionadas con permisos e inspecciones de tanques de almacenamiento de petróleo en Colorado."
       },
-      "url": "https://ops.colorado.gov/payment",
+      "url": "https://ops.colorado.gov/Conveyance/PaymentsFees",
       "department": {
         "en": "Department of Labor and Employment",
         "es": "Departamento de Trabajo y Empleo"
@@ -2724,7 +2724,7 @@
         "en": "Buy Colorado hunting licenses, including big game, small game, and combination licenses for residents and non-residents.",
         "es": "Compre licencias de caza de Colorado, incluyendo licencias de caza mayor, caza menor y combinadas para residentes y no residentes."
       },
-      "url": "https://www.cpwshop.com/",
+      "url": "https://www.cpwshop.com/home.page",
       "department": {
         "en": "Colorado Parks and Wildlife",
         "es": "Parques y Vida Silvestre de Colorado"
@@ -2756,7 +2756,7 @@
         "en": "Buy gift certificates that can be used for park passes, camping reservations, and other state park amenities.",
         "es": "Compre certificados de regalo que se pueden usar para pases de parques, reservaciones de campamentos y otras comodidades de parques estatales."
       },
-      "url": "https://www.cpwshop.com/",
+      "url": "https://www.cpwshop.com/home.page",
       "department": {
         "en": "Colorado Parks and Wildlife",
         "es": "Parques y Vida Silvestre de Colorado"
@@ -3780,7 +3780,7 @@
         "en": "Search and explore Colorado state parks based on available activities, amenities, accessibility features, and current conditions.",
         "es": "Busque y explore los parques estatales de Colorado basándose en actividades disponibles, comodidades, características de accesibilidad y condiciones actuales."
       },
-      "url": "https://cpw.state.co.us/placestogo/parks/Pages/default.aspx",
+      "url": "https://cpw.state.co.us/state-parks",
       "department": {
         "en": "Colorado Parks and Wildlife",
         "es": "Parques y Vida Silvestre de Colorado"
@@ -3812,7 +3812,7 @@
         "en": "Access real-time information about road conditions across Colorado, including weather impacts, construction, and travel alerts.",
         "es": "Acceda a información en tiempo real sobre condiciones de carreteras en todo Colorado, incluyendo impactos climáticos, construcción y alertas de viaje."
       },
-      "url": "https://www.cotrip.org/",
+      "url": "https://www.cotrip.org/home",
       "department": {
         "en": "Department of Transportation",
         "es": "Departamento de Transporte"
@@ -4356,7 +4356,7 @@
         "en": "Access comprehensive information about Colorado's K-12 education system, including academic standards, school choice options, and student support services.",
         "es": "Acceda a información completa sobre el sistema educativo K-12 de Colorado, incluyendo estándares académicos, opciones de elección escolar y servicios de apoyo estudiantil."
       },
-      "url": "https://www.cde.state.co.us/",
+      "url": "https://ed.cde.state.co.us/",
       "department": {
         "en": "Department of Education",
         "es": "Departamento de Educación"
@@ -5158,7 +5158,7 @@
         "en": "Submit an online application to become a certified instructor or training provider for meth lab cleanup in Colorado.",
         "es": "Envíe una solicitud en línea para convertirse en un instructor certificado o proveedor de capacitación para limpieza de laboratorios de metanfetaminas en Colorado."
       },
-      "url": "https://cdphe.colorado.gov/methlabcleanup",
+      "url": "https://cdphe.colorado.gov/hm/methlabcleanup",
       "department": {
         "en": "Department of Public Health & Environment",
         "es": "Departamento de Salud Pública y Medio Ambiente"
@@ -5317,7 +5317,7 @@
         "en": "Find information and resources on operating a licensed pet animal care facility in Colorado, including regulations and oversight.",
         "es": "Encuentre información y recursos sobre la operación de una instalación de cuidado de animales de compañía con licencia en Colorado, incluyendo regulaciones y supervisión."
       },
-      "url": "https://ag.colorado.gov/ics/pacfa",
+      "url": "https://ag.colorado.gov/animal-welfare/pet-animal-care-and-facilities-act",
       "department": {
         "en": "Department of Agriculture",
         "es": "Departamento de Agricultura"
@@ -5443,7 +5443,7 @@
         "en": "Submit a request for Colorado public records under the Colorado Open Records Act (CORA).",
         "es": "Envíe una solicitud de registros públicos de Colorado bajo la Ley de Registros Abiertos de Colorado (CORA)."
       },
-      "url": "https://oit.colorado.gov/cora-colorado-open-records-requests",
+      "url": "https://oit.colorado.gov/about-us/news/cora-colorado-open-records-requests",
       "department": {
         "en": "Office of Information Technology",
         "es": "Oficina de Tecnología de la Información"
@@ -5507,7 +5507,7 @@
         "en": "Access and manage your Colorado Parks and Wildlife digital hunting and fishing licenses via the CPW app or online portal.",
         "es": "Acceda y administre sus licencias digitales de caza y pesca de Parques y Vida Silvestre de Colorado a través de la aplicación CPW o el portal en línea."
       },
-      "url": "https://www.cpwshop.com/",
+      "url": "https://www.cpwshop.com/home.page",
       "department": {
         "en": "Colorado Parks and Wildlife",
         "es": "Parques y Vida Silvestre de Colorado"
@@ -5571,7 +5571,7 @@
         "en": "Apply for or renew a secure transportation service license, required for behavioral health secure transport providers.",
         "es": "Solicite o renueve una licencia de servicio de transporte seguro, requerida para proveedores de transporte seguro de salud conductual."
       },
-      "url": "https://cdphe.colorado.gov/emergency-care/emergency-medical-services",
+      "url": "https://cdphe.colorado.gov/ems",
       "department": {
         "en": "Department of Public Health & Environment",
         "es": "Departamento de Salud Pública y Medio Ambiente"
@@ -5757,7 +5757,7 @@
         "en": "Apply for Colorado Works, the state's Temporary Assistance for Needy Families (TANF) program that provides monthly cash assistance and employment support to families with children.",
         "es": "Solicite Colorado Works, el programa de Asistencia Temporal para Familias Necesitadas (TANF) del estado que proporciona asistencia en efectivo mensual y apoyo laboral a familias con hijos."
       },
-      "url": "https://cdhs.colorado.gov/benefits-assistance/cash-assistance/colorado-works-tanf",
+      "url": "https://cdhs.colorado.gov/colorado-works",
       "department": {
         "en": "Department of Human Services",
         "es": "Departamento de Servicios Humanos"
@@ -6425,7 +6425,7 @@
         "en": "Buy Colorado hunting, fishing, and outdoor recreation licenses through the official Colorado Parks and Wildlife online store.",
         "es": "Compre licencias de caza, pesca y recreación al aire libre de Colorado a través de la tienda oficial en línea de Parques y Vida Silvestre de Colorado."
       },
-      "url": "https://www.cpwshop.com/",
+      "url": "https://www.cpwshop.com/home.page",
       "department": {
         "en": "Colorado Parks and Wildlife",
         "es": "Parques y Vida Silvestre de Colorado"
@@ -6459,7 +6459,7 @@
         "en": "Check live road conditions, closures, travel alerts, and weather impacts across Colorado highways before you travel.",
         "es": "Consulte las condiciones de carreteras en vivo, cierres, alertas de viaje e impactos climáticos en las autopistas de Colorado antes de viajar."
       },
-      "url": "https://www.cotrip.org/",
+      "url": "https://www.cotrip.org/home",
       "department": {
         "en": "Department of Transportation",
         "es": "Departamento de Transporte"

--- a/workers/navigator-chat-proxy.js
+++ b/workers/navigator-chat-proxy.js
@@ -1,0 +1,168 @@
+/**
+ * navigator-chat-proxy — Cloudflare Worker
+ *
+ * Proxies chat messages from the Colorado Service Navigator to Gemini.
+ *
+ * Request body: { message, history?, catalog?, lang? }
+ *   - history: optional array of prior turns [{ role: 'user'|'assistant', text }]
+ *     so the assistant remembers the conversation. Capped server-side.
+ *   - catalog: legacy field (older clients sent the full catalog with every
+ *     message). If absent, the worker fetches the published catalog from the
+ *     site and caches it for an hour — preferred, saves ~100KB per message.
+ *
+ * Deploy: Cloudflare dashboard → Workers & Pages → navigator-chat-proxy →
+ * Edit code → replace contents with this file → Deploy.
+ * Required secret (already set): GEMINI_API_KEY
+ */
+
+const CATALOG_URL = 'https://colorado-gov.org/service-catalog-v8.json';
+const CATALOG_TTL_SECONDS = 3600;
+const MAX_HISTORY_TURNS = 10;
+const MAX_TURN_CHARS = 1500;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+async function loadCatalogSummary(lang) {
+  const cache = caches.default;
+  const cacheKey = new Request(CATALOG_URL);
+
+  let response = await cache.match(cacheKey);
+  if (!response) {
+    response = await fetch(CATALOG_URL, {
+      headers: { 'User-Agent': 'navigator-chat-proxy/2.0' },
+    });
+    if (!response.ok) return '';
+    response = new Response(response.body, response);
+    response.headers.set('Cache-Control', `s-maxage=${CATALOG_TTL_SECONDS}`);
+    await cache.put(cacheKey, response.clone());
+  }
+
+  const catalog = await response.json();
+  return (catalog.services || [])
+    .map(s => {
+      const name = (s.name && (s.name[lang] || s.name.en)) || '';
+      return `${name} | ${s.url}`;
+    })
+    .join('\n');
+}
+
+function legacyCatalogSummary(catalog) {
+  let services = [];
+  try {
+    services = typeof catalog === 'string' ? JSON.parse(catalog) : catalog;
+  } catch (e) {
+    services = [];
+  }
+  return (services || []).map(s => `${s.name} | ${s.url}`).join('\n');
+}
+
+function historyToContents(history) {
+  if (!Array.isArray(history)) return [];
+  return history
+    .slice(-MAX_HISTORY_TURNS)
+    .filter(turn => turn && typeof turn.text === 'string' && turn.text.trim())
+    .map(turn => ({
+      role: turn.role === 'assistant' ? 'model' : 'user',
+      parts: [{ text: String(turn.text).slice(0, MAX_TURN_CHARS) }],
+    }));
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: CORS_HEADERS });
+    }
+
+    if (request.method !== 'POST') {
+      return new Response('Method not allowed', { status: 405 });
+    }
+
+    try {
+      const { message, history, catalog, lang = 'en' } = await request.json();
+
+      const catalogSummary = catalog
+        ? legacyCatalogSummary(catalog)
+        : await loadCatalogSummary(lang);
+
+      const systemPrompts = {
+        en: `You help users find Colorado government services. Be concise (2-3 sentences max).
+
+RULES:
+- Format links as markdown: [Text](url)
+- Use EXACT URLs from the catalog - do not modify them
+- If no exact match, suggest searching the main site
+
+SERVICES:
+${catalogSummary}`,
+        es: `Ayudas a los usuarios a encontrar servicios gubernamentales de Colorado. Sé conciso (2-3 oraciones máximo). Responde siempre en español.
+
+REGLAS:
+- Formatea los enlaces como markdown: [Texto](url)
+- Usa las URLs EXACTAS del catálogo - no las modifiques
+- Si no hay coincidencia exacta, sugiere buscar en el sitio principal
+
+SERVICIOS:
+${catalogSummary}`,
+      };
+
+      const modelResponses = {
+        en: "Got it. I'll help find services using markdown links.",
+        es: 'Entendido. Ayudaré a encontrar servicios usando enlaces en markdown.',
+      };
+
+      const systemPrompt = systemPrompts[lang] || systemPrompts.en;
+      const modelResponse = modelResponses[lang] || modelResponses.en;
+
+      const contents = [
+        { role: 'user', parts: [{ text: systemPrompt }] },
+        { role: 'model', parts: [{ text: modelResponse }] },
+        ...historyToContents(history),
+        { role: 'user', parts: [{ text: String(message || '').slice(0, MAX_TURN_CHARS) }] },
+      ];
+
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${env.GEMINI_API_KEY}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents,
+            generationConfig: {
+              temperature: 0.2,
+              maxOutputTokens: 2048,
+              stopSequences: [],
+            },
+          }),
+        }
+      );
+
+      const data = await response.json();
+
+      if (data.error) {
+        return new Response(JSON.stringify({ error: data.error.message }), {
+          headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+        });
+      }
+
+      const defaultReply =
+        lang === 'es'
+          ? 'No pude encontrar servicios relevantes. Intente usar la barra de búsqueda.'
+          : "I couldn't find relevant services. Try the search bar above.";
+
+      const reply = data.candidates?.[0]?.content?.parts?.[0]?.text || defaultReply;
+
+      return new Response(JSON.stringify({ reply }), {
+        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+      });
+    } catch (error) {
+      return new Response(JSON.stringify({ error: 'Service unavailable' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
+      });
+    }
+  },
+};

--- a/workers/navigator-chat-proxy.js
+++ b/workers/navigator-chat-proxy.js
@@ -12,13 +12,24 @@
  *
  * Deploy: Cloudflare dashboard → Workers & Pages → navigator-chat-proxy →
  * Edit code → replace contents with this file → Deploy.
- * Required secret (already set): GEMINI_API_KEY
+ *
+ * Environment:
+ *   - GEMINI_API_KEY (secret, required)
+ *   - GEMINI_MODEL (optional) — overrides the model id without a redeploy.
+ *     Defaults to gemini-3.5-flash.
+ *   - GEMINI_THINKING_LEVEL (optional) — minimal | low | medium | high.
+ *     Defaults to "low": this is a simple service-lookup task, so we keep
+ *     thinking cheap and fast. Gemini 3.5 enables thinking at "medium" by
+ *     default, which would add latency and token cost for no real benefit
+ *     here. Raise it only if answer quality needs it.
  */
 
 const CATALOG_URL = 'https://colorado-gov.org/service-catalog-v8.json';
 const CATALOG_TTL_SECONDS = 3600;
 const MAX_HISTORY_TURNS = 10;
 const MAX_TURN_CHARS = 1500;
+const DEFAULT_MODEL = 'gemini-3.5-flash';
+const DEFAULT_THINKING_LEVEL = 'low';
 
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
@@ -124,17 +135,25 @@ ${catalogSummary}`,
         { role: 'user', parts: [{ text: String(message || '').slice(0, MAX_TURN_CHARS) }] },
       ];
 
+      const model = env.GEMINI_MODEL || DEFAULT_MODEL;
+      const thinkingLevel = env.GEMINI_THINKING_LEVEL || DEFAULT_THINKING_LEVEL;
+
+      // Gemini 3.5 migration notes:
+      // - temperature / top_p / top_k are no longer recommended on 3.x
+      //   thinking models; the strict system prompt handles grounding.
+      // - thinkingConfig.thinkingLevel replaces the old thinking_budget.
+      // - thinking tokens count toward maxOutputTokens, so we leave headroom
+      //   above the short answer we actually want.
       const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${env.GEMINI_API_KEY}`,
+        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${env.GEMINI_API_KEY}`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             contents,
             generationConfig: {
-              temperature: 0.2,
-              maxOutputTokens: 2048,
-              stopSequences: [],
+              maxOutputTokens: 4096,
+              thinkingConfig: { thinkingLevel },
             },
           }),
         }


### PR DESCRIPTION
Three improvements from the code-review follow-up list, plus a Gemini 3.5 Flash upgrade to the chat worker.

## ⚠️ One manual step BEFORE merging

The chat worker needs updating first (a 2-minute copy-paste):

1. Open the **Cloudflare dashboard** → **Workers & Pages** → **navigator-chat-proxy**
2. Click **Edit code**
3. Replace the entire contents with the new file from this PR: [`workers/navigator-chat-proxy.js`](https://github.com/bntcurtis/colorado-digital-services-navigator/blob/feat/chat-and-filters/workers/navigator-chat-proxy.js) (click "Raw", select-all, copy)
4. Click **Deploy**, then merge this PR

**Optional env vars** (Settings → Variables) — the worker has sensible defaults, so these are only if you want to tune:
- `GEMINI_MODEL` — defaults to `gemini-3.5-flash`. Set to `gemini-3-flash-preview` to roll the model back.
- `GEMINI_THINKING_LEVEL` — `minimal` | `low` | `medium` | `high`, defaults to `low`.

(The new worker works with the current live site too, so deploying it first is safe.)

## 1. Gemini 3.5 Flash upgrade
Model bumped from `gemini-3-flash-preview` to `gemini-3.5-flash` (now GA), made env-configurable. Applied the real 3.5 migration changes — removed `temperature` (no longer recommended on 3.x thinking models) and set thinking to **`low`** rather than 3.5's `medium` default, since service lookup doesn't need heavy reasoning and you're cost-conscious. Output budget raised to 4096 because thinking tokens now count against it.

## 2. The chatbot now remembers the conversation
Previously every message was sent alone — asking "is there a fee for that?" drew a blank. The chat now sends the last 10 turns. The browser also no longer uploads the full 100KB catalog with every message; the worker fetches and caches it (1h), with Spanish service names in Spanish mode.

## 3. All 39 departments are now filterable
The department filter silently showed only the top 12. Both filter groups now show 12 with a bilingual **"Show all (39)"** toggle. Verified in-browser.

## 4. The 18 duplicate-URL conflicts are resolved (catalog v8.1.3)
Applied 18 verified redirect targets the repair agent kept declining to auto-apply (because the destination already belonged to another service). All 13 unique destinations re-checked as HTTP 200. Weekly "unresolved" count should drop from ~30 to ~12. A few entries now share a URL (e.g. the CPW shop entries) — merging those near-duplicates is an editorial call left for the monthly review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)